### PR TITLE
Additional Error Codes

### DIFF
--- a/Go365.go
+++ b/Go365.go
@@ -278,8 +278,6 @@ func flagOptions() *flagVars {
 
 	flag.Parse()
 
-	fmt.Println(*flagUserPassFile)
-
 	return &flagVars{
 		flagHelp:         *flagHelp,
 		flagUsername:     *flagUsername,

--- a/Go365.go
+++ b/Go365.go
@@ -213,6 +213,9 @@ func doTheStuff(un string, pw string, prox string) (string, color.Attribute) {
 	} else if strings.Contains(x.Text(), "AADSTS50126") {
 		returnString = "[-] Valid user, but invalid password: " + un + " : " + pw
 		returnColor = color.FgYellow
+	} else if strings.Contains(x.Text(), "AADSTS50055") {
+		returnString = "[!] Valid user, expired password: " + un + " : " + pw
+		returnColor = color.FgGreen
 	} else if strings.Contains(x.Text(), "AADSTS50056") {
 		returnString = "[!] User exists, but unable to determine if the password is correct: " + un + " : " + pw
 		returnColor = color.FgYellow
@@ -222,8 +225,14 @@ func doTheStuff(un string, pw string, prox string) (string, color.Attribute) {
 	} else if strings.Contains(x.Text(), "AADSTS50057") {
 		returnString = "[-] Account disabled: " + un
 		returnColor = color.FgMagenta
+	} else if strings.Contains(x.Text(), "AADSTS50076") || strings.Contains(x.Text(), "AADSTS50079")
+		returnString = "[+] Possible valid login, MFA required. " + un + " : " + pw
+		returnColor = color.FgGreen
+	} else if strings.Contains(x.Text(), "AADSTS53004") {
+		returnString = "[+] Possible valid login, user must enroll in MFA. " + un + " : " + pw
+		returnColor = color.FgGreen
 	} else {
-		returnString = "[-] Unknown response. " + un + " : " + pw
+		returnString = "[!] Unknown response, run with -debug flag for more information. " + un + " : " + pw
 		returnColor = color.FgMagenta
 	}
 
@@ -268,6 +277,8 @@ func flagOptions() *flagVars {
 	flagDebug := flag.Bool("debug", false, "")
 
 	flag.Parse()
+
+	fmt.Println(*flagUserPassFile)
 
 	return &flagVars{
 		flagHelp:         *flagHelp,

--- a/Go365.go
+++ b/Go365.go
@@ -215,7 +215,7 @@ func doTheStuff(un string, pw string, prox string) (string, color.Attribute) {
 		returnColor = color.FgYellow
 	} else if strings.Contains(x.Text(), "AADSTS50055") {
 		returnString = "[!] Valid user, expired password: " + un + " : " + pw
-		returnColor = color.FgGreen
+		returnColor = color.FgMagenta
 	} else if strings.Contains(x.Text(), "AADSTS50056") {
 		returnString = "[!] User exists, but unable to determine if the password is correct: " + un + " : " + pw
 		returnColor = color.FgYellow

--- a/Go365.go
+++ b/Go365.go
@@ -55,8 +55,8 @@ const (
                               - Username with or without "@domain.com"
                               (-u legit.user)
      -ul <file>             Username list to use
-															- File should contain one username per line
-															- Usernames can have "@domain.com"
+                              - File should contain one username per line
+                              - Usernames can have "@domain.com"
                               - If no domain is specified, the -d domain is used
                               (-ul ./usernamelist.txt)
      -p <string>            Password to attempt
@@ -67,7 +67,7 @@ const (
                               - Must be used with -delay (delay)
                               (-pl ./passwordlist.txt)
      -up <file>            Userpass list to use
-															- One username and password separated by a ":" per line
+                              - One username and password separated by a ":" per line
                               - Be careful of duplicate usernames!
                               (-up ./userpasslist.txt)
      -d <string>            Domain to test

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Go365 is a tool designed to perform user enumeration and password guessing attac
 
 ## Obtaining
 
+#### Option 0
+
+```
+go get -u github.com/optiv/Go365
+```
+
 #### Option 1
 
 Download a pre-compiled binary for your OS [HERE](https://github.com/optiv/Go365/releases).


### PR DESCRIPTION
Added error codes for the following cases:

`AADSTS50055` - Valid user, expired password
`AADSTS50076` - Possible valid login, MFA required.
`AADSTS53004` - Possible valid login, user must enroll in MFA.

Added install option in README

```
go get -u github.com/optiv/Go365
```