### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/eatonchips/Go365
+module github.com/optiv/Go365
 
 go 1.16
 


### PR DESCRIPTION
It was causing this error while installing the module :
```
go: downloading github.com/optiv/Go365 v0.0.0-20210915033106-f181d30cf087
go get: github.com/optiv/Go365@v0.0.0-20210915033106-f181d30cf087: parsing go.mod:
	module declares its path as: github.com/eatonchips/Go365
	        but was required as: github.com/optiv/Go365
```